### PR TITLE
Added support for new fields EndPoint and TreatFailedRunAsError

### DIFF
--- a/Cake.Tools.ReadyAPI.TestEngine.Tests/TestEngineRunnerTests_Endpoint.cs
+++ b/Cake.Tools.ReadyAPI.TestEngine.Tests/TestEngineRunnerTests_Endpoint.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using Xunit;
+
+namespace Cake.Tools.ReadyAPI.TestEngine.Tests
+{
+    public partial class TestEngineRunnerTests
+    {
+        [Fact]
+        public void GetArguments_EndPointProvidedHasArgument()
+        {
+            var settings = new TestEngineSettings
+            {
+                EndPoint = "localhost:8080"
+            };
+
+            var args = TestEngineRunner.GetArguments(string.Empty, settings);
+
+            Assert.Equal(1, args.Count(argument => argument.Render() == "endpoint=localhost:8080"));
+        }
+
+        [Fact]
+        public void GetArguments_EmptyEndPointNoArgument()
+        {
+            var settings = new TestEngineSettings
+            {
+                EndPoint = string.Empty
+            };
+
+            var args = TestEngineRunner.GetArguments(string.Empty, settings);
+
+            Assert.Equal(0, args.Count(argument => argument.Render().StartsWith("endpoint")));
+        }
+
+        [Fact]
+        public void GetArguments_NullEndPointNoArgument()
+        {
+            var settings = new TestEngineSettings
+            {
+                EndPoint = null
+            };
+
+            var args = TestEngineRunner.GetArguments(string.Empty, settings);
+
+            Assert.Equal(0, args.Count(argument => argument.Render().StartsWith("endpoint")));
+        }
+    }
+}

--- a/Cake.Tools.ReadyAPI.TestEngine.Tests/TestEngineRunnerTests_TreatFailedRunAsError.cs
+++ b/Cake.Tools.ReadyAPI.TestEngine.Tests/TestEngineRunnerTests_TreatFailedRunAsError.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using Xunit;
+
+namespace Cake.Tools.ReadyAPI.TestEngine.Tests
+{
+    public partial class TestEngineRunnerTests
+    {
+        [Fact]
+        public void GetArguments_TreatFailedRunAsErrorTrueHasArgument()
+        {
+            var settings = new TestEngineSettings
+            {
+                TreatFailedRunAsError = true
+            };
+
+            var args = TestEngineRunner.GetArguments(string.Empty, settings);
+
+            Assert.Equal(1, args.Count(argument => argument.Render() == "treatFailedRunAsError"));
+        }
+
+        [Fact]
+        public void GetArguments_TreatFailedRunAsErrorFalseNoArgument()
+        {
+            var settings = new TestEngineSettings
+            {
+                TreatFailedRunAsError = false
+            };
+
+            var args = TestEngineRunner.GetArguments(string.Empty, settings);
+
+            Assert.Equal(0, args.Count(argument => argument.Render() == "treatFailedRunAsError"));
+        }
+
+        [Fact]
+        public void GetArguments_TreatFailedRunAsErrorNullNoArgument()
+        {
+            var settings = new TestEngineSettings
+            {
+                TreatFailedRunAsError = null
+            };
+
+            var args = TestEngineRunner.GetArguments(string.Empty, settings);
+
+            Assert.Equal(0, args.Count(argument => argument.Render() == "treatFailedRunAsError"));
+        }
+    }
+}

--- a/Cake.Tools.ReadyAPI.TestEngine/Cake.Tools.ReadyAPI.TestEngine.csproj
+++ b/Cake.Tools.ReadyAPI.TestEngine/Cake.Tools.ReadyAPI.TestEngine.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Cake.Tools.ReadyAPI.TestEngine/TestEngineRunner.cs
+++ b/Cake.Tools.ReadyAPI.TestEngine/TestEngineRunner.cs
@@ -82,6 +82,11 @@ namespace Cake.Tools.ReadyAPI.TestEngine
 
             arguments.Append("run project");
 
+            if (!string.IsNullOrWhiteSpace(settings.EndPoint))
+            {
+                arguments.Append($"endpoint={settings.EndPoint}");
+            }
+
             if (!string.IsNullOrWhiteSpace(settings.TestCase))
             {
                 arguments.Append($"testcase={settings.TestCase}");
@@ -105,6 +110,11 @@ namespace Cake.Tools.ReadyAPI.TestEngine
             if (settings.PrintReport == true)
             {
                 arguments.Append("printReport");
+            }
+
+            if (settings.TreatFailedRunAsError == true)
+            {
+                arguments.Append("treatFailedRunAsError");
             }
 
             if (settings.PriorityJob == true)

--- a/Cake.Tools.ReadyAPI.TestEngine/TestEngineSettings.cs
+++ b/Cake.Tools.ReadyAPI.TestEngine/TestEngineSettings.cs
@@ -126,6 +126,11 @@ namespace Cake.Tools.ReadyAPI.TestEngine
         public int? TimeoutSeconds { get; set; }
 
         /// <summary>
+        /// Return an error when the project returns a "FAILED" result.
+        /// </summary>
+        public bool? TreatFailedRunAsError { get; set; }
+
+        /// <summary>
         /// Specifies the username used to connect to TestEngine.
         /// </summary>
         public string Username { get; set; }
@@ -134,5 +139,10 @@ namespace Cake.Tools.ReadyAPI.TestEngine
         /// Enables more detailed output.
         /// </summary>
         public bool? Verbose { get; set; }
+
+        /// <summary>
+        /// The endpoint to be used for HTTP requests sent by this test, in the format host:[port].
+        /// </summary>
+        public string EndPoint { get; set; }
     }
 }


### PR DESCRIPTION
Both fields are pending approval from SmartBear and inclusion in to the testengine-cli package.  Please do not use.